### PR TITLE
Adding support for long player and game names

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -24,7 +24,6 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         justifyContent: 'center',
         textAlign: 'center',
-        flexWrap: 'wrap',
     },
     headerText: {
         fontFamily: 'Quicksand',

--- a/components/Tooltip.tsx
+++ b/components/Tooltip.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react'
+import { Modal, StyleSheet, Text, View, TouchableOpacity } from 'react-native'
+import { WrapperComponentProps } from '../model/component';
+import { sharedStyles } from '../styles/shared';
+
+type TooltipProps = {
+    text: string;
+}
+
+// TODO this is in progress
+const Tooltip = ({children, text}: TooltipProps & WrapperComponentProps) => {
+    const [modalVisible, setModalVisible] = useState(false);
+
+    return (
+        <View>
+            <Modal
+                animationType='fade'
+                transparent={true}
+                visible={modalVisible}
+            >
+                <TouchableOpacity
+                    activeOpacity={1}
+                    onPressOut={() => {setModalVisible(false)}}
+                >
+                    <Text style={[ sharedStyles.bodyText ]}>
+                        {text}
+                    </Text>
+                </TouchableOpacity>
+            </Modal>
+            <TouchableOpacity
+                    onLongPress={() => {setModalVisible(true)}}
+                >
+                {children}
+            </TouchableOpacity>
+        </View>
+    )
+}
+
+export default Tooltip;

--- a/hooks/abbrevaiteNumber.test.ts
+++ b/hooks/abbrevaiteNumber.test.ts
@@ -1,0 +1,28 @@
+import { abbreviate } from './abbreviateNumber';
+
+describe('abbreviateNumber', () => {
+    it('should return number as is if less than max', () => {
+        const result = abbreviate(900, 999);
+        expect(result).toEqual('900');
+    });
+
+    it('should return negative number as is if less than max', () => {
+        const result = abbreviate(-900, 999);
+        expect(result).toEqual('-900');
+    });
+
+    it('should return abbreviated number if greater than max and equal to a floor', () => {
+        const result = abbreviate(1000, 999);
+        expect(result).toEqual('1.00K');
+    });
+
+    it('should return abbreviated number if greater than max', () => {
+        const result = abbreviate(123456, 999);
+        expect(result).toEqual('123.46K');
+    });
+
+    it('should return negtive abbreviated number if greater than max', () => {
+        const result = abbreviate(-8675309, 999);
+        expect(result).toEqual('-8.68M');
+    });
+});

--- a/hooks/abbreviateNumber.ts
+++ b/hooks/abbreviateNumber.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+
+const abbreviations = [
+    {
+        floor: 1e15,
+        abbreviation: 'Q',
+    },
+    {
+        floor: 1e12,
+        abbreviation: 'T',
+    },
+    {
+        floor: 1e9,
+        abbreviation: 'B',
+    },
+    {
+        floor: 1e6,
+        abbreviation: 'M',
+    },
+    {
+        floor: 1e3,
+        abbreviation: 'K',
+    },
+];
+
+export function abbreviate(value: number, max: number = 999): string {
+    if (Math.abs(value) < max) {
+        return value.toString();
+    }
+    let sign = '';
+    if (value < 0) {
+        value = Math.abs(value);
+        sign = '-';
+    }
+    const abbreviation = abbreviations.find(({ floor }) => (value / floor) >= 1);
+    if (abbreviation) {
+        const shortenedValue = (value / abbreviation.floor).toFixed(2);
+        const abbreviatedValue = `${shortenedValue}${abbreviation.abbreviation}`;
+        return `${sign}${abbreviatedValue}`;
+    }
+    return `${sign}${value}`;
+}
+
+export function abbreviateNumber(value: number, max: number = 999): string {
+    const [truncatedValue, setTruncatedValue] = useState<string>('');
+    useEffect(() => {
+        setTruncatedValue(abbreviate(value, max));
+    }, [value, max]);
+
+    return truncatedValue;
+}

--- a/hooks/truncateString.ts
+++ b/hooks/truncateString.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+
+export function truncateText(text: string, maxLength: number): string {
+    const [truncatedText, setTruncatedText] = useState<string>('');
+
+    useEffect(() => {
+        if (text.length > maxLength) {
+            setTruncatedText(`${text.slice(0, maxLength - 3)}...`)
+        } else {
+            setTruncatedText(text)
+        }
+    }, [text]);
+
+    return truncatedText;
+}

--- a/pages/game-scores/components/GamePlayerScoresTable.tsx
+++ b/pages/game-scores/components/GamePlayerScoresTable.tsx
@@ -6,6 +6,7 @@ import { Player } from '../../../model/player';
 import { GameScoreHistory } from '../../../model/game-score-history';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import { gameContext } from '../../../state/game.store';
+import GamePlayerScoresTablePlayerCell from './GamePlayerScoresTablePlayerCell';
 
 type GamePlayerScoresTableProps = {
     players: Player[],
@@ -24,7 +25,7 @@ let roundScrollRef: ScrollView;
 export const GamePlayerScoresTable = ({
     players, scoreHistoryRounds, scoreHistory, editable = true, playersSelectable = false
 }: GamePlayerScoresTableProps) => {
-    const {setActivePlayer, activeGamePlayerScore} = useContext(gameContext);
+    const {activeGamePlayerScore} = useContext(gameContext);
 
     useEffect(() => {
         scrollPosition.addListener(position => {
@@ -69,19 +70,12 @@ export const GamePlayerScoresTable = ({
                     <View style={[styles.players]}>
                         {
                             players.map(player => (
-                                <View style={[sharedStyles.plainRow]} key={player.key}>
-                                    {
-                                        playersSelectable ?
-                                        <TouchableOpacity onPress={() => setActivePlayer(player)}>
-                                            <Text style={[sharedStyles.bodyText, activeGamePlayerScore?.player.key === player.key ? sharedStyles.editingCell : sharedStyles.touchableCell, sharedStyles.p5]}>
-                                                {player.name}
-                                            </Text>
-                                        </TouchableOpacity> :
-                                        <Text style={[sharedStyles.bodyText, sharedStyles.p5]}>
-                                            {player.name}
-                                        </Text>
-                                    }
-                                </View>
+                                <GamePlayerScoresTablePlayerCell
+                                    key={player.key}
+                                    selectable={playersSelectable}
+                                    player={player}
+                                    active={activeGamePlayerScore?.player.key === player.key}
+                                />
                             ))
                         }
                     </View>

--- a/pages/game-scores/components/GamePlayerScoresTablePlayerCell.tsx
+++ b/pages/game-scores/components/GamePlayerScoresTablePlayerCell.tsx
@@ -1,0 +1,38 @@
+import React, { useContext } from 'react'
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { truncateText } from '../../../hooks/truncateString'
+import { Player } from '../../../model/player'
+import { gameContext } from '../../../state/game.store'
+import { sharedStyles } from '../../../styles/shared'
+
+type GamePlayerScoresTablePlayerCellProps = {
+    selectable: boolean;
+    player: Player;
+    active: boolean;
+}
+
+const GamePlayerScoresTablePlayerCell = ({ selectable, player, active }: GamePlayerScoresTablePlayerCellProps) => {
+    const {setActivePlayer} = useContext(gameContext);
+
+    const displayName = truncateText(player.name, 7);
+
+    return (
+        <View style={[sharedStyles.plainRow, { minWidth: 50 }]} key={player.key}>
+            {
+                selectable ?
+                <TouchableOpacity onPress={() => setActivePlayer(player)}>
+                    <Text style={[sharedStyles.bodyText, active ? sharedStyles.editingCell : sharedStyles.touchableCell, sharedStyles.p5, { minWidth: 50 }]}>
+                        {displayName}
+                    </Text>
+                </TouchableOpacity> :
+                <Text style={[sharedStyles.bodyText, sharedStyles.p5, { minWidth: 50 }]}>
+                    {displayName}
+                </Text>
+            }
+        </View>
+    )
+}
+
+export default GamePlayerScoresTablePlayerCell;
+
+const styles = StyleSheet.create({});

--- a/pages/game-scores/components/GamePlayerScoresTableRow.tsx
+++ b/pages/game-scores/components/GamePlayerScoresTableRow.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Text, View } from 'react-native'
 import { PlayerScoreHistory } from '../../../model/player-score-history'
 import { sharedStyles } from '../../../styles/shared'
-import GamePlayerScoresTableCell from './GamePlayerScoresTableCell'
+import GamePlayerScoresTableScoreCell from './GamePlayerScoresTableScoreCell'
 
 type GamePlayerScoresTableProps = {
     playerScoreHistory: PlayerScoreHistory;
@@ -14,14 +14,13 @@ const GamePlayerScoresTableRow = ({ playerScoreHistory, editable }: GamePlayerSc
             {
                 playerScoreHistory.scores.length ?
                 playerScoreHistory.scores.map((s, i) => (
-                    editable ?
-                        <GamePlayerScoresTableCell
-                            score={s}
-                            scoreIndex={i}
-                            playerKey={playerScoreHistory.playerKey}
-                            key={`${playerScoreHistory.key}-${s}-${i}`}
-                        /> :
-                        <Text style={[sharedStyles.scoreTabelCell]} key={`${playerScoreHistory.key}-${s}-${i}`}>{s}</Text>
+                    <GamePlayerScoresTableScoreCell
+                        score={s}
+                        scoreIndex={i}
+                        playerKey={playerScoreHistory.playerKey}
+                        key={`${playerScoreHistory.key}-${s}-${i}`}
+                        editable={editable}
+                    />
                 )) : <View style={[sharedStyles.scoreTabelCell]}></View>
             }
         </View>

--- a/pages/game-scores/components/GamePlayerScoresTableScoreCell.tsx
+++ b/pages/game-scores/components/GamePlayerScoresTableScoreCell.tsx
@@ -5,13 +5,16 @@ import { sharedStyles } from '../../../styles/shared';
 import { gameContext } from '../../../state/game.store';
 import { connectActionSheet, useActionSheet } from '@expo/react-native-action-sheet';
 import { colors } from '../../../styles/colors';
+import { abbreviateNumber } from '../../../hooks/abbreviateNumber';
 
-type GamePlayerScoresTableCellProps = {
+type GamePlayerScoresTableScoreCellProps = {
     playerKey: string;
     scoreIndex: number;
     score: number;
+    editable: boolean;
 }
-const GamePlayerScoresTableCell = ({ playerKey, score, scoreIndex }: GamePlayerScoresTableCellProps) => {
+
+const GamePlayerScoresTableScoreCell = ({ playerKey, score, scoreIndex, editable }: GamePlayerScoresTableScoreCellProps) => {
     const {editPlayerScore, deletePlayerScore, editingPlayerScore} = useContext(gameContext);
 
     const [isBeingEdited, setIsBeingEdited] = useState(false);
@@ -23,8 +26,10 @@ const GamePlayerScoresTableCell = ({ playerKey, score, scoreIndex }: GamePlayerS
 
     const { showActionSheetWithOptions } = useActionSheet();
 
+    const displayScore = abbreviateNumber(score);
+
     return (
-        <TouchableOpacity onPress={() => showActionSheetWithOptions({
+        editable ? <TouchableOpacity onPress={() => showActionSheetWithOptions({
             options: [ 'Edit', 'Delete', 'Cancel'],
             tintColor: colors.primary,
             cancelButtonIndex: 2,
@@ -38,10 +43,11 @@ const GamePlayerScoresTableCell = ({ playerKey, score, scoreIndex }: GamePlayerS
             }
         })}>
             <Text style={[sharedStyles.scoreTabelCell, isBeingEdited ?  sharedStyles.editingCell : sharedStyles.touchableCell ]}>
-                {score}
+                {displayScore}
             </Text>
-        </TouchableOpacity>
+        </TouchableOpacity> :
+        <Text style={[sharedStyles.scoreTabelCell]}>{displayScore}</Text>
     );
 }
 
-export default connectActionSheet(GamePlayerScoresTableCell);
+export default connectActionSheet(GamePlayerScoresTableScoreCell);

--- a/pages/game/Game.tsx
+++ b/pages/game/Game.tsx
@@ -13,6 +13,8 @@ import { RouteName as GameScoresRoute } from '../game-scores/GameScores';
 import GamePlayerScoresTable from '../game-scores/components/GamePlayerScoresTable';
 import GestureRecognizer from 'react-native-swipe-gestures';
 import { PlayerScoreMode } from '../../model/player-score';
+import { truncateText } from '../../hooks/truncateString';
+import Tooltip from '../../components/Tooltip';
 
 const Game = ({ navigation }: PageNavigationProps<typeof RouteName>) => {
     const {
@@ -68,6 +70,8 @@ const Game = ({ navigation }: PageNavigationProps<typeof RouteName>) => {
         runFadeAnimation(1);
     };
 
+    const displayName = truncateText(activeGamePlayerScore?.player?.name ?? '', 10);
+
     return ( activeGamePlayerScore ?
         <View style={sharedStyles.pageContainer}>
             <View style={styles.gameContainer}>
@@ -80,7 +84,7 @@ const Game = ({ navigation }: PageNavigationProps<typeof RouteName>) => {
                             navigation.navigate(GameScoresRoute, { gameOver: true });
                         }}}
                     />
-                    <View style={[sharedStyles.centeredContent, sharedStyles.mt25 ]}>
+                    <View style={[sharedStyles.centeredContent, sharedStyles.mt10 ]}>
                         {
                             <Animated.View style={[{ transform: [{ translateX: slideAnim}]}, { opacity: fadeAnim }]}>
                                 <MaterialCommunityIcons name={'crown'} size={28} color={winningPlayerKey === activeGamePlayerScore.player.key ? colors.tertiary : colors.white } />
@@ -92,7 +96,9 @@ const Game = ({ navigation }: PageNavigationProps<typeof RouteName>) => {
                             <IconButton icon='chevron-left' clickHandler={changePlayerLeft} width={'100%'} size={34} />
                         </View>
                         <Animated.View style={[styles.buttonRowItem, { opacity: fadeAnim }, { transform: [{ translateX: slideAnim}]}]}>
-                            <Header title={activeGamePlayerScore.player.name}/>
+                            {/* <Tooltip text={activeGamePlayerScore.player.name}> */}
+                            <Header title={displayName}/>
+                            {/* </Tooltip> */}
                         </Animated.View>
                         <View style={[styles.buttonRowItem]}>
                             <IconButton icon='chevron-right' clickHandler={changePlayerRight} width={'100%'} size={34} />
@@ -111,7 +117,7 @@ const Game = ({ navigation }: PageNavigationProps<typeof RouteName>) => {
                             </Text>
                         </View>
                     </Animated.View>
-                    <View style={[sharedStyles.spacedEvenlyNoBorder, sharedStyles.mt10 ]}>
+                    <View style={[sharedStyles.spacedEvenlyNoBorder ]}>
                         <View style={[styles.buttonRowItem]}>
                             <IconButton icon='plus-minus' clickHandler={() => turnScore && updateTurnScore(turnScore * -1)} size={34}/>
                         </View>

--- a/styles/shared.ts
+++ b/styles/shared.ts
@@ -140,7 +140,7 @@ export const sharedStyles = StyleSheet.create({
         height: 150
     },
     scoreTabelCell: {
-        minWidth: 30,
+        minWidth: 60,
         minHeight: 28,
         padding: 5,
         marginRight: 20,


### PR DESCRIPTION
Closes #3 

Adding support for longer player names/game names and scores

Score table:

Player Names

- Min-width used (50px)
- Truncate name and add ellipsis if > 7 character name

Scores

- Added functionality to abbreviate scores larger than 999 for example 1200 becomes 1.20K etc.

Game:

Player Names

- Truncate name and add ellipsis if > 9 character name
- Center text
- Remove some spacing and decrease font size
